### PR TITLE
feat(get-one-item-usecase): Se agrego el use case get-one-item-usecas…

### DIFF
--- a/core/app/waste_item/application/use_cases/get_one_item_by_id.py
+++ b/core/app/waste_item/application/use_cases/get_one_item_by_id.py
@@ -1,0 +1,8 @@
+from core.app.waste_item.domain.ports import WasteItemRepository
+
+class GetOneItemByIdUseCase:
+    def __init__(self, waste_item_repository: WasteItemRepository):
+        self.waste_item_repository = waste_item_repository
+
+    def execute(self, waste_item_id: str):
+        return self.waste_item_repository.get(waste_item_id)

--- a/core/tests/waste-item/use_cases/get_one_item_by_id.py
+++ b/core/tests/waste-item/use_cases/get_one_item_by_id.py
@@ -1,0 +1,42 @@
+import unittest
+from unittest.mock import MagicMock
+from core.app.waste_item.domain.ports import WasteItemRepository
+from core.app.waste_item.application.use_cases.get_one_item_by_id import GetOneItemByIdUseCase
+
+class TestGetOneItemByIdUseCase(unittest.TestCase):
+    def setUp(self):
+        # Crear un mock del repositorio
+        self.mock_repository = MagicMock(spec=WasteItemRepository)
+        self.use_case = GetOneItemByIdUseCase(self.mock_repository)
+
+    def test_execute_returns_item(self):
+        # Configurar el mock para devolver un elemento
+        waste_item_id = "123"
+        expected_item = {"id": waste_item_id, "name": "Plastic Bottle"}
+        self.mock_repository.get.return_value = expected_item
+
+        # Ejecutar el caso de uso
+        result = self.use_case.execute(waste_item_id)
+
+        # Verificar que el repositorio fue llamado correctamente
+        self.mock_repository.get.assert_called_once_with(waste_item_id)
+
+        # Verificar que el resultado sea el esperado
+        self.assertEqual(result, expected_item)
+
+    def test_execute_item_not_found(self):
+        # Configurar el mock para devolver None
+        waste_item_id = "999"
+        self.mock_repository.get.return_value = None
+
+        # Ejecutar el caso de uso
+        result = self.use_case.execute(waste_item_id)
+
+        # Verificar que el repositorio fue llamado correctamente
+        self.mock_repository.get.assert_called_once_with(waste_item_id)
+
+        # Verificar que el resultado sea None
+        self.assertIsNone(result)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Added GetOneItemByIdUseCase with Unit Tests
This pull request implements the GetOneItemByIdUseCase along with comprehensive unit tests. The use case follows the clean architecture pattern and provides functionality to retrieve a waste item by its ID from the repository.
Changes include:

Created new use case class in core/app/waste_item/application/use_cases/get_one_item_by_id.py
Added unit tests in core/tests/waste-item/use_cases/get_one_item_by_id.py with test cases for successful item retrieval and item not found scenarios
Maintained repository interface dependency injection for better testability

Testing:
All unit tests pass successfully, verifying both the retrieval of existing items and proper handling of non-existent items.Reintentar[Claude puede cometer errores. Por favor, verifique las respuestas.](https://support.anthropic.com/en/articles/8525154-claude-is-providing-incorrect-or-misleading-responses-what-s-going-on) test