### PR TITLE
feat(endpoint stats material) End point stats material y stats all ma…

### DIFF
--- a/api/waste_item/urls.py
+++ b/api/waste_item/urls.py
@@ -1,9 +1,11 @@
 from django.urls import path
 
-from api.waste_item.views import WasteImageScanApiView, WasteItemApiView, WasteItemByIdApiView
+from api.waste_item.views import WasteImageScanApiView, WasteItemApiView, WasteItemByIdApiView, StatsAllMaterialWaste, StatsMaterialWaste
 
 urlpatterns = [
     path("waste-item", WasteItemApiView.as_view(), name="crud-waste-item"),
     path("waste-item/scan", WasteImageScanApiView.as_view(), name="scan-waste-item"),
-    path("waste-item/<str:waste_item_id>", WasteItemByIdApiView.as_view(), name="get-waste-item-id")
+    path("waste-item/<str:waste_item_id>", WasteItemByIdApiView.as_view(), name="get-waste-item-id"),
+    path("waste-item/stats", StatsAllMaterialWaste.as_view(), name="stats-waste-item"),
+    path("waste-item/stats/<str:material_waste>", StatsMaterialWaste.as_view(), name="stats-waste-item-material"),
 ]

--- a/api/waste_item/views.py
+++ b/api/waste_item/views.py
@@ -12,6 +12,8 @@ from core.app.waste_item.domain.entities import Image, WasteItemInfo, WasteItemT
 from core.app.waste_item.application.use_cases.list_all_items import ListAllItemsUseCase
 from rest_framework.permissions import AllowAny
 from core.app.waste_item.application.use_cases.get_one_item_by_id import GetOneItemByIdUseCase
+from core.app.waste_item.application.use_cases.get_all_recycling_material import GetAllRecyclingMaterialUseCase
+from core.app.waste_item.application.use_cases.get_objets_recycling_material import CountMaterialAmountUseCase
 
 class WasteItemApiView(APIView):
     parser_classes = (MultiPartParser,)
@@ -75,8 +77,34 @@ class WasteItemByIdApiView(APIView):
             print(e)
             status_response, detail = get_error_status_code_from_exception(e)
             return Response(status=status_response, data=detail)   
-         
+        
+class StatsAllMaterialWaste(APIView):
+    @staticmethod
+    def get(self, request, *args, **kwargs):
+        ## definicion del repo
+        repository = WasteItemRepositoryImpl()
+        use_case = GetAllRecyclingMaterialUseCase(waste_item_repository=repository)
+        try:
+            waste_items = use_case.execute()
+            return Response(waste_items)
+        except Exception as e:
+            print(e)
+            status_response, detail = get_error_status_code_from_exception(e)
+            return Response(status=status_response, data=detail)
 
+class StatsMaterialWaste(APIView):
+    @staticmethod
+    def get(self, request, material_waste, *args, **kwargs):
+        ## definicion del repo
+        repository = WasteItemRepositoryImpl()
+        use_case = CountMaterialAmountUseCase(waste_item_repository=repository)
+        try:
+            waste_items = use_case.execute(material_waste=material_waste)
+            return Response(waste_items)
+        except Exception as e:
+            print(e)
+            status_response, detail = get_error_status_code_from_exception(e)
+            return Response(status=status_response, data=detail)
 
 
 class WasteImageScanApiView(APIView):


### PR DESCRIPTION
…terial
Basado en los cambios mostrados en el diff de código, se están añadiendo nuevas funcionalidades para estadísticas de materiales de desecho en la API. La PR incluye:

1. Dos nuevas rutas URL:
   - `/waste-item/stats` para obtener estadísticas de todos los materiales reciclables
   - `/waste-item/stats/<str:material_waste>` para obtener estadísticas de un material específico

2. Dos nuevas vistas (clases):
   - `StatsAllMaterialWaste`: implementa el endpoint para obtener estadísticas generales de todos los materiales
   - `StatsMaterialWaste`: implementa el endpoint para obtener estadísticas de un material específico

3. Integración con dos nuevos casos de uso:
   - `GetAllRecyclingMaterialUseCase`: para listar todos los materiales reciclables 
   - `CountMaterialAmountUseCase`: para contar la cantidad de elementos por tipo de material

Estos cambios permiten al sistema proporcionar análisis estadísticos sobre los diferentes tipos de materiales de desecho registrados, lo que facilitará la visualización y el seguimiento del reciclaje por categoría de material.