### PR TITLE
fix(to entity waste item) se arreglo un error de lógica del método to…

### DIFF
--- a/api/waste_item/models.py
+++ b/api/waste_item/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from core.app.waste_item.domain.entities import WasteItem as WasteItemEntity
+from core.app.waste_item.domain.entities import WasteItem as WasteItemEntity, WasteItemType
 # Create your models here.
 
 WasteItemTypes = [
@@ -43,7 +43,7 @@ class WasteItem(models.Model):
             user_id=self.user.id,
             image=self.image,
             material=self.material,
-            type=types[self.type.name],
+            type=WasteItemType(self.type),  # <-- convierte a Enum si es necesario
             approximate_weight=self.approximate_weight,
             created_at=self.created_at,
             updated_at=self.updated_at,


### PR DESCRIPTION
… entity
# 🔄 Update WasteItem Model Type Conversion

## Overview
This pull request addresses an important change in how waste item types are handled in the Django model to ensure proper type conversion between the database model and the domain entity.

## Problem
The current implementation uses a dictionary lookup (`types[self.type.name]`) to convert between the database representation and the domain entity representation of waste item types. This approach is error-prone and doesn't leverage the type safety that could be provided by proper enum handling.

## Solution
The PR modifies the `to_entity()` method in the `WasteItem` model to directly use the `WasteItemType` enum for type conversion, ensuring that the types are properly mapped between the database layer and the domain layer.

```python
# Before
type=types[self.type.name]

# After
type=WasteItemType(self.type)
```

## Changes
- 📝 Updated import statement to include `WasteItemType` from the domain entities
- 🛠️ Modified the type conversion in `to_entity()` method to use the enum constructor directly
- 🔄 Removed dependency on the manual mapping dictionary for type conversion

## Benefits
- 🔒 **Type Safety**: Ensures proper type conversion using the enum system
- 🐛 **Bug Prevention**: Eliminates potential errors from dictionary lookups with invalid keys
- 🧹 **Code Cleanliness**: Removes unnecessary mapping logic and simplifies the conversion process

## Testing
- ✅ Verified that the model correctly converts database types to domain entity types
- ✅ Ensured backward compatibility with existing records
- ✅ Confirmed that all waste item types (recyclable, organic, non_recyclable) are properly handled

## Next Steps
- Consider updating other areas of the codebase that might still be using manual type conversions
- Add validation to ensure that only valid waste item types can be stored in the database

## Implementation Notes
- The comment `# <-- convierte a Enum si es necesario` has been left in the code to explain the purpose of this conversion for future developers